### PR TITLE
Enable Full Extraction through GitHub Actions

### DIFF
--- a/.github/workflows/extraction.yml
+++ b/.github/workflows/extraction.yml
@@ -1,6 +1,6 @@
-name: Sample Extraction
+name: Extraction
 
-on: [pull_request]
+on: [pull_request,push]
 
 jobs:
   extract:
@@ -15,15 +15,29 @@ jobs:
       with:
         rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@master
+    - name: Get Commit Message
+      run: echo ::set-env name=COMMIT_MESSAGE::$(git log --format=%B -n 1 ${{ github.event.after }})
+
     - uses: futuratrepadeira/changed-files@b4ef6fe
+      if: "contains( github.ref , 'pull' )"
       id: files
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Sample extraction
-      run: ./scripts/sample-extraction.sh
+
+    - name: Full Extraction
+      if: "contains( env.COMMIT_MESSAGE , '--full-extraction' )"
+      run: ./scripts/extraction.sh full
       env:
         FILES_CREATED: ${{ steps.files.outputs.files_created }}
         FILES_UPDATED: ${{ steps.files.outputs.files_updated }}
+
+    - name: Sample Extraction
+      if: "!contains( env.COMMIT_MESSAGE , '--full-extraction' )"
+      run: ./scripts/extraction.sh
+      env:
+        FILES_CREATED: ${{ steps.files.outputs.files_created }}
+        FILES_UPDATED: ${{ steps.files.outputs.files_updated }}
+
     - uses: actions/upload-artifact@v1
       with:
         name: extraction-sample

--- a/.github/workflows/wiki-extraction.yml
+++ b/.github/workflows/wiki-extraction.yml
@@ -38,6 +38,10 @@ jobs:
         FILES_CREATED: ${{ steps.files.outputs.files_created }}
         FILES_UPDATED: ${{ steps.files.outputs.files_updated }}
 
+    - name: Deduplicate Wikipedia Extraction
+      if: "contains( env.COMMIT_MESSAGE , '--full-wiki-extraction' )"
+      run: ./scripts/dedupe.sh wiki.txt
+
     - uses: actions/upload-artifact@v1
       with:
         name: extraction

--- a/.github/workflows/wiki-extraction.yml
+++ b/.github/workflows/wiki-extraction.yml
@@ -1,4 +1,4 @@
-name: Extraction
+name: Wikipedia Extraction
 
 on: [pull_request,push]
 
@@ -24,21 +24,21 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Full Extraction
-      if: "contains( env.COMMIT_MESSAGE , '--full-extraction' )"
-      run: ./scripts/extraction.sh full
+    - name: Full Wikipedia Extraction
+      if: "contains( env.COMMIT_MESSAGE , '--full-wiki-extraction' )"
+      run: ./scripts/wiki-extraction.sh full
       env:
         FILES_CREATED: ${{ steps.files.outputs.files_created }}
         FILES_UPDATED: ${{ steps.files.outputs.files_updated }}
 
-    - name: Sample Extraction
-      if: "!contains( env.COMMIT_MESSAGE , '--full-extraction' )"
-      run: ./scripts/extraction.sh
+    - name: Sample Wikipedia Extraction
+      if: "!contains( env.COMMIT_MESSAGE , '--full-wiki-extraction' )"
+      run: ./scripts/wiki-extraction.sh
       env:
         FILES_CREATED: ${{ steps.files.outputs.files_created }}
         FILES_UPDATED: ${{ steps.files.outputs.files_updated }}
 
     - uses: actions/upload-artifact@v1
       with:
-        name: extraction-sample
+        name: extraction
         path: output/

--- a/README.md
+++ b/README.md
@@ -191,10 +191,14 @@ If you find a new open data source that provides a lot of sentences ([Example](h
 
 ## Automatic extraction
 
+Currently the following data sources are available for automatic extraction:
+
+* Wikipedia
+
 ### On every Pull Request
 
 On every PR we will [trigger a sample sentence extraction](https://discourse.mozilla.org/t/scraper-automatic-sample-sentences-extracted-in-pull-request/55217/3) which can be used for verification.
 
 ### On pushes to master
 
-On every push to master, we will run a full sentence extraction on the specified language if the commit message includes `--full-extraction=<language>` at the end of the message.
+On every push to master, we will run a full sentence extraction on the specified language if the commit message includes `--full-wiki-extraction=<language>` at the end of the message.

--- a/README.md
+++ b/README.md
@@ -188,3 +188,13 @@ If you find a new open data source that provides a lot of sentences ([Example](h
 * In `app.rs`, add a new extraction command - same arguments as the `extract` task, but with a better - more descriptive - name identifying your data source
 * In `loader.rs` write your own loader according to the data structure - the data structure should be fairly simple, you might need to consider writing a separate script to fetch and prepare the sentences first (as we do with the WikiExtractor for Wikipedia)
 * In `app.rs` add a new `else if` in the `start` function to generate your config and start the extraction, passing your own custom loader you wrote
+
+## Automatic extraction
+
+### On every Pull Request
+
+On every PR we will [trigger a sample sentence extraction](https://discourse.mozilla.org/t/scraper-automatic-sample-sentences-extracted-in-pull-request/55217/3) which can be used for verification.
+
+### On pushes to master
+
+On every push to master, we will run a full sentence extraction on the specified language if the commit message includes `--full-extraction=<language>` at the end of the message.

--- a/scripts/dedupe.sh
+++ b/scripts/dedupe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+FILE_NAME=$1
+WORKSPACE=${GITHUB_WORKSPACE:-/tmp}
+OUTPUT_PATH="$WORKSPACE/output"
+FILE_PATH="$OUTPUT_PATH/$FILE_NAME"
+OUTPUT_FILE="$OUTPUT_PATH/wiki-sorted-unique.txt"
+
+if [[ -f "$FILE_PATH" ]]; then
+  echo "Sorting and deduplicating $FILE_PATH"
+  sort -u $FILE_PATH > $OUTPUT_FILE
+fi

--- a/scripts/extraction.sh
+++ b/scripts/extraction.sh
@@ -11,50 +11,7 @@ WIKI_EXTRACTOR_PATH="$WORKSPACE/WikiExtractor.py"
 EXTRACTED_TEXT_PATH="$WORKSPACE/text"
 OUTPUT_PATH="$WORKSPACE/output"
 EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/extraction-sample.txt"
-
 mkdir -p $OUTPUT_PATH
-
-if [ $TYPE == "sample" ]; then
-  echo "Files created: $FILES_CREATED"
-  echo "Files updated: $FILES_UPDATED"
-  echo "Analyzing first rule file changed.."
-  ALL_FILES="$FILES_CREATED $FILES_UPDATED"
-  FIRST_CHANGED_RULES_FILE=( $(echo $ALL_FILES | grep -o 'src/rules/.*' || [[ $? == 1 ]]) )
-
-  if [ ${#FIRST_CHANGED_RULES_FILE[@]} == 0 ]; then
-    echo "Nothing to be done here.."
-    echo "" > $EXTRACTED_SENTENCES_PATH
-    exit 0
-  fi
-
-  LANGUAGE_FILE_NAME=${FIRST_CHANGED_RULES_FILE/src\/rules\//""}
-  LANGUAGE_FILE_NAME=${LANGUAGE_FILE_NAME/disallowed_words\//""}
-  LANGUAGE=${LANGUAGE_FILE_NAME/.toml/""}
-  LANGUAGE_CODE=${LANGUAGE/.txt/""}
-elif [ $TYPE == "full" ]; then
-  echo "Commit: $COMMIT_MESSAGE"
-  EXTRACTION_OPTION=$(echo $COMMIT_MESSAGE | grep -o -e '--full-extraction=.*$' || [[ $? == 1 ]])
-  LANGUAGE_CODE=${EXTRACTION_OPTION/"--full-extraction="/""}
-fi
-
-echo "Determined that we should run an export for $LANGUAGE_CODE"
-
-echo "Getting WikiExtractor"
-curl $WIKI_EXTRACTOR_URL > $WIKI_EXTRACTOR_PATH
-
-echo "Downloading Dump Listing..."
-DUMP_BASE_PATH="https://dumps.wikimedia.org/${LANGUAGE_CODE}wiki/latest/"
-curl $DUMP_BASE_PATH > listing.html
-
-echo "Searching for correct file..."
-ARCHIVE_FILE_NAME_MATCHES=$(grep -o -e 'wiki-latest-pages-articles-multistream1.xml.*bz2' < listing.html || [[ $? == 1 ]])
-if [ -z $ARCHIVE_FILE_NAME_MATCHES ]; then
-  ARCHIVE_FILE_NAME_MATCHES=$(grep -o -e 'wiki-latest-pages-articles-multistream.xml.bz2' < listing.html)
-fi
-rm listing.html
-
-ARCHIVE_FILE_NAME=$(echo $ARCHIVE_FILE_NAME_MATCHES | head -n1 | awk '{print $1;}')
-
 
 function dump {
   DUMP_URL="${DUMP_BASE_PATH}${LANGUAGE_CODE}$1"
@@ -91,10 +48,51 @@ function cleanup {
   rm -rf $EXTRACTED_TEXT_PATH
 }
 
-function main {
-  dump $ARCHIVE_FILE_NAME
-  extract
-  cleanup
-}
 
-main
+if [ $TYPE == "sample" ]; then
+  echo "Files created: $FILES_CREATED"
+  echo "Files updated: $FILES_UPDATED"
+  echo "Analyzing first rule file changed.."
+  ALL_FILES="$FILES_CREATED $FILES_UPDATED"
+  FIRST_CHANGED_RULES_FILE=( $(echo $ALL_FILES | grep -o 'src/rules/.*' || [[ $? == 1 ]]) )
+
+  if [ ${#FIRST_CHANGED_RULES_FILE[@]} == 0 ]; then
+    echo "Nothing to be done here.."
+    echo "" > $EXTRACTED_SENTENCES_PATH
+    exit 0
+  fi
+
+  LANGUAGE_FILE_NAME=${FIRST_CHANGED_RULES_FILE/src\/rules\//""}
+  LANGUAGE_FILE_NAME=${LANGUAGE_FILE_NAME/disallowed_words\//""}
+  LANGUAGE=${LANGUAGE_FILE_NAME/.toml/""}
+  LANGUAGE_CODE=${LANGUAGE/.txt/""}
+elif [ $TYPE == "full" ]; then
+  echo "Commit: $COMMIT_MESSAGE"
+  EXTRACTION_OPTION=$(echo $COMMIT_MESSAGE | grep -o -e '--full-extraction=.*$' || [[ $? == 1 ]])
+  LANGUAGE_CODE=${EXTRACTION_OPTION/"--full-extraction="/""} # TODO: make this prettier by only returing matched language
+fi
+
+echo "Determined that we should run an export for $LANGUAGE_CODE"
+
+echo "Getting WikiExtractor"
+curl $WIKI_EXTRACTOR_URL > $WIKI_EXTRACTOR_PATH
+
+echo "Downloading Dump Listing..."
+DUMP_BASE_PATH="https://dumps.wikimedia.org/${LANGUAGE_CODE}wiki/latest/"
+curl $DUMP_BASE_PATH > listing.html
+
+echo "Searching for correct files..."
+ARCHIVE_FILE_NAME_MATCHES=($(grep -o  -P -e 'wiki-latest-pages-articles-multistream\d*.xml-.*bz2"' < listing.html || [[ $? == 1 ]]))
+if [ ${#ARCHIVE_FILE_NAME_MATCHES[@]} == 0 ]; then
+  ARCHIVE_FILE_NAME_MATCHES=($(grep -o  -P -e 'wiki-latest-pages-articles-multistream.xml.bz2"' < listing.html))
+fi
+rm listing.html
+
+for archive in "${ARCHIVE_FILE_NAME_MATCHES[@]}"
+do
+    ARCHIVE_FILE_NAME=${archive/%?/}
+    echo "Starting extraction for ... $ARCHIVE_FILE_NAME" # TODO: make this prettier and not even return " when grepping...
+    dump $ARCHIVE_FILE_NAME
+    extract
+    cleanup
+done

--- a/scripts/wiki-extraction.sh
+++ b/scripts/wiki-extraction.sh
@@ -49,6 +49,8 @@ function cleanup {
 
 
 if [ $TYPE == "sample" ]; then
+  EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/extraction-sample.txt"
+
   echo "Files created: $FILES_CREATED"
   echo "Files updated: $FILES_UPDATED"
   echo "Analyzing first rule file changed.."
@@ -65,7 +67,6 @@ if [ $TYPE == "sample" ]; then
   LANGUAGE_FILE_NAME=${LANGUAGE_FILE_NAME/disallowed_words\//""}
   LANGUAGE=${LANGUAGE_FILE_NAME/.toml/""}
   LANGUAGE_CODE=${LANGUAGE/.txt/""}
-  EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/extraction-sample.txt"
 elif [ $TYPE == "full" ]; then
   echo "Commit: $COMMIT_MESSAGE"
   EXTRACTION_OPTION=$(echo $COMMIT_MESSAGE | grep -o -e '--full-wiki-extraction=.*$' || [[ $? == 1 ]])

--- a/scripts/wiki-extraction.sh
+++ b/scripts/wiki-extraction.sh
@@ -10,7 +10,6 @@ WIKI_EXTRACTOR_URL="https://raw.githubusercontent.com/attardi/wikiextractor/mast
 WIKI_EXTRACTOR_PATH="$WORKSPACE/WikiExtractor.py"
 EXTRACTED_TEXT_PATH="$WORKSPACE/text"
 OUTPUT_PATH="$WORKSPACE/output"
-EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/extraction-sample.txt"
 mkdir -p $OUTPUT_PATH
 
 function dump {
@@ -66,10 +65,12 @@ if [ $TYPE == "sample" ]; then
   LANGUAGE_FILE_NAME=${LANGUAGE_FILE_NAME/disallowed_words\//""}
   LANGUAGE=${LANGUAGE_FILE_NAME/.toml/""}
   LANGUAGE_CODE=${LANGUAGE/.txt/""}
+  EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/extraction-sample.txt"
 elif [ $TYPE == "full" ]; then
   echo "Commit: $COMMIT_MESSAGE"
-  EXTRACTION_OPTION=$(echo $COMMIT_MESSAGE | grep -o -e '--full-extraction=.*$' || [[ $? == 1 ]])
-  LANGUAGE_CODE=${EXTRACTION_OPTION/"--full-extraction="/""} # TODO: make this prettier by only returing matched language
+  EXTRACTION_OPTION=$(echo $COMMIT_MESSAGE | grep -o -e '--full-wiki-extraction=.*$' || [[ $? == 1 ]])
+  LANGUAGE_CODE=${EXTRACTION_OPTION/"--full-wiki-extraction="/""} # TODO: make this prettier by only returing matched language
+  EXTRACTED_SENTENCES_PATH="$OUTPUT_PATH/wiki.txt"
 fi
 
 echo "Determined that we should run an export for $LANGUAGE_CODE"


### PR DESCRIPTION
This enables full extraction through GitHub Actions. If we pass `--full-extraction=<locale>` in the merge commit after accepting a rule, it will automatic generate the full extraction file. Then we just need to download that sample and add it to the voice-web repo.

Example for ca: https://github.com/MichaelKohler/common-voice-wiki-scraper/runs/501975370?check_suite_focus=true (one big dump file, but Actions can still handle it)
Example for es: https://github.com/MichaelKohler/common-voice-wiki-scraper/runs/503056319?check_suite_focus=true (many smaller dumps we iterate over)

Caveat: if there are multiple dump files, we run the extractor multiple times and therefore might end up with duplicates. I'll add a deduplicate step in a later PR.

@nukeador can you have a look at the Spanish run and check if there is something obviously wrong so we have double checked this PR?