### PR TITLE
Add initial rules and blacklist for Belarusian

### DIFF
--- a/src/rules/be.toml
+++ b/src/rules/be.toml
@@ -1,5 +1,5 @@
 min_trimmed_length = 3
-min_word_count = 3
+min_word_count = 5
 max_word_count = 14
 min_characters = 1
 may_end_with_colon = false
@@ -7,7 +7,8 @@ quote_start_with_letter = true
 needs_punctuation_end = true
 needs_letter_start = true
 needs_uppercase_start = true
-allowed_symbols_regex = "[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў\\s:,.\\-‑?;!—­‐–'·=’―−‘«»]"
+# allow letters, apostrophe, spaces, ",.!?" and different variants of dashes "-"
+allowed_symbols_regex = "[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў'\\s,.\\-‑?!—­‐–―−]"
 disallowed_symbols = []
 broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;", " \""]
 matching_symbols = [
@@ -29,6 +30,7 @@ replacements = [
   [" - ", " — "], # hyphen => U+2014, when between whitespaces
 ]
 
+# выдаляем сказы з наступнымі абрэвіятурамі:
 abbreviation_patterns = [
   # Я. Колас
   "[А-ЗЙ-ШЫ-ЯЁІЎ]\\.",
@@ -48,13 +50,22 @@ abbreviation_patterns = [
   "[а-зй-шы-яёіў]{1,3}\\.-[а-зй-шы-яёіў]{1,4}\\.",
   # напр.,
   "\\.,",
-  # сімвал «-»
+  # з радкамі: "«-»", "«:»", "«'»"
   "«[-:']»",
   # Frequent sentence-final abbreviations
   "[^А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў](—|а|аа|аг|адз|анг|англ|апубл|арт|арх|б|балг|бел|бл|в|вобл|вул|выд|вял|г|гадз|гв|гг|гл|гр|грэч|д|дал|дзес|др|е|еп|ж|жых|з|зав|заг|зах|зб|зв|зн|і|імп|інш|ісп|італ|к|кав|кам|кар|кв|кг|км|кн|кс|л|лац|м|Матф|мкм|мл|млн|млрд|мм|мн|мяст|мясц|н|напр|нар|нац|нм|ням|п|пав|пад|палк|пам|пар|паст|пач|пд|пл|пн|пр|праф|прп|псеўд|р|рас|рт|рус|рэд|с|сав|сапр|св|свв|скар|сл|см|сп|ст|стст|суч|сяр|т|тыс|у|ф|фр|х|хв|хім|ц|ч|чыг|ш|шт|э|экз|яп)\\.$",
 ]
 
+# выдаляем сказы, якія задавальняюць іншым правілам:
 other_patterns = [
+  # выдаляем сказы з уласнымі імёнамі (пачынаюцца зь вялікай літары).
+  # пошук вялікіх літараў вядзецца не з пачатку сказу,
+  # бо адрозьніць уласныя імёны на пачатку сказа ад звычайных словаў цяжка.
+  # праз тое што мы карыстаем гэты фільтр для выдаленьня ўласных імёнаў, 
+  # можна прыбраць некаторыя правілы ў сьпісе з абрэвіятурамі, кшталту фільтрацыі "Я. Колас" і падобных абрэвіятураў.
+  # аднак я іх пакіну, каб можна было карыстаць у будучыні пры патрэбе.
+  ".+([А-ЗЙ-ШЫ-ЯЁІЎ])",
+
   # Invalid punctuation at the end of the sentence
   "[^.!?]$",
   # Two or more dots in a row
@@ -64,7 +75,7 @@ other_patterns = [
   # Asymmetric whitespaces around a dash
   "[а-зй-шы-яёіў](—\\s|\\s—)[а-зй-шы-яёіў]",
   # No whitespaces around a dash
-  "[А-ЗЙ-ШЫ-ЯЁІЎ]—[А-ЗЙ-ШЫ-ЯЁІЎ]",
+  "[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў]—[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў]",
   # Very frequent sentence-initial patterns, would skew the sentence distribution if allowed
   "^(Адміністрацыйны цэнтр|Уваходзіць у склад|Сядзіба размешчана ў)\\s",
   # Character patterns that occur in Russian but not Belarusian words

--- a/src/rules/be.toml
+++ b/src/rules/be.toml
@@ -1,0 +1,72 @@
+min_trimmed_length = 3
+min_word_count = 3
+max_word_count = 14
+min_characters = 1
+may_end_with_colon = false
+quote_start_with_letter = true
+needs_punctuation_end = true
+needs_letter_start = true
+needs_uppercase_start = true
+allowed_symbols_regex = "[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў\\s:,.\\-‑?;!—­‐–'·=’―−‘«»]"
+disallowed_symbols = []
+broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;", " \""]
+matching_symbols = [
+  ["«", "»"],
+  # No need to balance "’" with "‘" because in Belarusian texts
+  # they are typically used as apostrophes, not quotes
+]
+replacements = [
+  ["‘", "'"],     # U+2018 => apostrophe
+  ["’", "'"],     # U+2019 => apostrophe
+  ["­", ""],       # U+00AD => empty string
+  [" ", " "],     # U+00A0 => whitespace
+  [" ", " "],     # U+2002 => whitespace
+  [" ", " "],     # U+202F => whitespace
+  ["‑", "-"],     # U+2011 => hyphen
+  ["–", "—"],     # U+2013 => U+2014
+  ["―", "—"],     # U+2015 => U+2014
+  ["−", "—"],     # U+2212 => U+2014
+  [" - ", " — "], # hyphen => U+2014, when between whitespaces
+]
+
+abbreviation_patterns = [
+  # Я. Колас
+  "[А-ЗЙ-ШЫ-ЯЁІЎ]\\.",
+  # Зм. Бядуля
+  "[А-ЗЙ-ШЫ-ЯЁІЎ][а-зй-шы-яёіў]\\.",
+  # БССР
+  "[А-ЗЙ-ШЫ-ЯЁІЎ]{2,}",
+  # Дзяржынскага р-на
+  "р-н[аеу]?[^а-яёўі]",
+  # Жыгімонт І Стары (Belarusian I, U+406)
+  "[^ІХа-зй-шы-яёіў][ІХ][^ІХа-зй-шы-яёіў']",
+  # г.Ляхавічы
+  "[а-зй-шы-яёіў]\\.[А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў]",
+  # в. Заброддзе
+  "\\s[а-зй-шы-яёіў]\\.",
+  # ст.-бел.
+  "[а-зй-шы-яёіў]{1,3}\\.-[а-зй-шы-яёіў]{1,4}\\.",
+  # напр.,
+  "\\.,",
+  # сімвал «-»
+  "«[-:']»",
+  # Frequent sentence-final abbreviations
+  "[^А-ЗЙ-ШЫ-ЯЁІЎа-зй-шы-яёіў](—|а|аа|аг|адз|анг|англ|апубл|арт|арх|б|балг|бел|бл|в|вобл|вул|выд|вял|г|гадз|гв|гг|гл|гр|грэч|д|дал|дзес|др|е|еп|ж|жых|з|зав|заг|зах|зб|зв|зн|і|імп|інш|ісп|італ|к|кав|кам|кар|кв|кг|км|кн|кс|л|лац|м|Матф|мкм|мл|млн|млрд|мм|мн|мяст|мясц|н|напр|нар|нац|нм|ням|п|пав|пад|палк|пам|пар|паст|пач|пд|пл|пн|пр|праф|прп|псеўд|р|рас|рт|рус|рэд|с|сав|сапр|св|свв|скар|сл|см|сп|ст|стст|суч|сяр|т|тыс|у|ф|фр|х|хв|хім|ц|ч|чыг|ш|шт|э|экз|яп)\\.$",
+]
+
+other_patterns = [
+  # Invalid punctuation at the end of the sentence
+  "[^.!?]$",
+  # Two or more dots in a row
+  "\\.{2,}",
+  # Two dashes in a row
+  "— —",
+  # Asymmetric whitespaces around a dash
+  "[а-зй-шы-яёіў](—\\s|\\s—)[а-зй-шы-яёіў]",
+  # No whitespaces around a dash
+  "[А-ЗЙ-ШЫ-ЯЁІЎ]—[А-ЗЙ-ШЫ-ЯЁІЎ]",
+  # Very frequent sentence-initial patterns, would skew the sentence distribution if allowed
+  "^(Адміністрацыйны цэнтр|Уваходзіць у склад|Сядзіба размешчана ў)\\s",
+  # Character patterns that occur in Russian but not Belarusian words
+  "(ть?ся[^а-зй-шы-яёіў]|[дтржшчДТРЖШЧ][ьеёюя]|[бвп]ь[^а-зй-шы-яёіў]|[^р]вс|ого[^а-зй-шы-яёіў]|о([бвдзклмнпрстфх]|[дтзс]н)о)",
+]


### PR DESCRIPTION
> - How many sentences did you get at the end?

155178 sentences.

> - How did you create the blocklist file?

I followed the procedure suggested in the README, with a few enhancements:
- `word_usage.py` doesn't support Cyrillic characters, so I tweaked a regex inside the script. This should probably be filed as an issue in cvtools.
- As the dataset is not very large, the frequency threshold is set to 4.
- From the list obtained this way, I removed all wordforms that occur in the grammatical database of Belarusian, available [here](https://github.com/volchek/beltagger) (presumably they are good, if the grammatical database knows them).

There are ~450K tokens in the blocklist. I visually inspected a small sample thereof – many items are indeed typos or spelling errors, but the majority are infrequent proper names (especially foreign ones) and specialized terminology.

> - Get at least 3 different native speakers (ideally linguists) to review a random sample of 100-500 sentences and estimate the average error ratio and comment (or link their comment) in the PR.

I've sampled 800 sentences randomly (`shuf -n 800 wiki.be.txt`) and split them into four samples of 200 sentences each. The samples are available [here](https://gist.github.com/somerandomguyontheweb/66ee3504cd7b1ade0d6acd34072b7347). I'm going to review one sample myself, and @volchek agreed to review another one (she is a linguist and a native speaker of Belarusian). Now seeking for two more native speakers – if I can't find any volunteers, I'll contact the localization team.

One more remark: In addition to the modern orthography (_narkamaŭka_), Belarusian has a traditional orthography (_taraškievica_), which is relatively widespread and preferred by some speakers. That's the reason why there exist two Wikipedias in Belarusian: be.wikipedia.org and be-tarask.wikipedia.org. I'm scraping be.wikipedia.org, which is larger and appears to be more actively maintained.