### PR TITLE
Update from hk

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently it only works for the chinese wiki.
 - randomly extract at most 3 sentences per article
 - skip disambiguation pages
 - skip title
-- cutting sentence with these symbols `，`, `。`, `、`, `：`, `？`, `；`, `！`
+- cutting sentence with these symbols `，`, `。`, `、`, `：`, `？`, `；`, `！`, `（` & `）`
 - show the ending symbol if it is `？` or `！`
 - skip sentences that...
   - start with non-alphabetic characters

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Currently it only works for the chinese wiki.
 - randomly extract at most 3 sentences per article
 - skip disambiguation pages
 - skip title
+- cutting sentence with these symbols `，`, `。`, `、`, `：`, `？`, `；`, `！`
+- show the ending symbol if it is `？` or `！`
 - skip sentences that...
-    - start with non-alphabetic characters
-    - contain ascii characters
-    - contain only non-alphabetic characters
-    - are shorter than 3 characters (can be changed with `-s` option)
-    - are longer than 38 characters (can be changed with `-l` option)
+  - start with non-alphabetic characters
+  - contain ascii characters
+  - contain only non-alphabetic characters
+  - are shorter than 3 characters (can be changed with `-s` option)
+  - are longer than 38 characters (can be changed with `-l` option)
 
 ## Options
 - replaces traditional characters with their simplified counterpart (with `-t` option)
 - ignore symbols (with `-i` option)
-- cutting long sentence with auxiliary symbols (with `-a` option)
-- choping the ending symbol of a sentence (with `-c` option)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -60,14 +60,6 @@ where
                         .help("The suitable longest sentence length"),
                 )
                 .arg(
-                    Arg::with_name("auxiliary symbols")
-                        .short("a")
-                        .long("aux")
-                        .takes_value(true)
-                        .number_of_values(1)
-                        .help("The auxiliary symbols for extracting long sentence"),
-                )
-                .arg(
                     Arg::with_name("ignore symbols")
                         .short("i")
                         .long("ignore")
@@ -75,12 +67,6 @@ where
                         .number_of_values(1)
                         .help("The symbols will be ignored when extracting"),
                 )
-                .arg(
-                    Arg::with_name("chop ending symbol")
-                        .short("c")
-                        .long("chop")
-                        .help("chop the ending symbol"),
-                ),
         )
         .get_matches_from(itr)
 }
@@ -111,12 +97,6 @@ fn extract(matches: &ArgMatches) -> Result<()> {
         .unwrap_or("38")
         .parse::<usize>()
         .unwrap();
-    let mut auxiliary_symbols: Vec<char> = matches
-        .value_of("auxiliary symbols")
-        .unwrap_or("")
-        .chars()
-        .map(|c| SYMBOL_MAP.get(&c).unwrap_or(&c).clone())
-        .collect();
     let ignore_symbols: Vec<char> = matches
         .value_of("ignore symbols")
         .unwrap_or("")
@@ -126,11 +106,9 @@ fn extract(matches: &ArgMatches) -> Result<()> {
 
     let mut builder = SentenceExtractorBuilder::new()
         .translate(matches.is_present("trans"))
-        .chop_ending_symbol(matches.is_present("chop ending symbol"))
         .shortest_length(shortest_length)
         .longest_length(longest_length)
-        .auxiliary_symbols(&mut auxiliary_symbols)?
-        .ignore_symbols(&ignore_symbols)?;
+        .ignore_symbols(&ignore_symbols);
 
     let mut sentences = vec![];
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,61 +7,54 @@ fn test_extractor() {
     let mut builder = SentenceExtractorBuilder::new();
     let mut iter = builder.build(texts[0].as_str());
 
-    assert_eq!(iter.next().unwrap(), "愛因斯坦係一位理論物理學家");
+    assert_eq!(iter.next().unwrap(), "愛因斯坦（");
+    assert_eq!(iter.next().unwrap(), "全名音譯");
+    assert_eq!(iter.next().unwrap(), "阿爾拔·愛因斯坦");
     assert_eq!(iter.next().unwrap(), "佢最出名嘅係發表咗相對論");
-    assert_eq!(
-        iter.next().unwrap(),
-        "另外喺量子力學、統計力學、同埋宇宙學方面都有好大貢獻"
-    );
-    assert_eq!(
-        iter.next().unwrap(),
-        "愛因斯坦喺德國烏爾姆市出世，一年後成家人搬咗去慕尼黑"
-    );
-    assert_eq!(iter.next().unwrap(), "佢屋企都係猶太人，但係冇入猶太教");
-    assert_eq!(iter.next().unwrap(), "佢爸爸本來賣床褥，後來開電器舖");
-    assert_eq!(
-        iter.next().unwrap(),
-        "五歲嗰年，佢爸爸送咗個指南針畀佢，佢就發現有啲睇唔到嘅嘢牽引住枝針"
-    );
+    assert_eq!(iter.next().unwrap(), "另外喺量子力學");
+    assert_eq!(iter.next().unwrap(), "統計力學");
+    assert_eq!(iter.next().unwrap(), "同埋宇宙學方面都有好大貢獻");
+    assert_eq!(iter.next().unwrap(), "愛因斯坦喺德國烏爾姆市出世");
+    assert_eq!(iter.next().unwrap(), "一年後成家人搬咗去慕尼黑");
+    assert_eq!(iter.next().unwrap(), "佢屋企都係猶太人");
+    assert_eq!(iter.next().unwrap(), "但係冇入猶太教");
+    assert_eq!(iter.next().unwrap(), "佢爸爸本來賣床褥");
+    assert_eq!(iter.next().unwrap(), "後來開電器舖");
+    assert_eq!(iter.next().unwrap(), "五歲嗰年");
+    assert_eq!(iter.next().unwrap(), "佢爸爸送咗個指南針畀佢");
+    assert_eq!(iter.next().unwrap(), "佢就發現有啲睇唔到嘅嘢牽引住枝針");
     assert_eq!(
         iter.next().unwrap(),
         "後來愛因斯坦話嗰次嘅經驗係佢一生中最有啟發性"
     );
-    assert_eq!(
-        iter.next().unwrap(),
-        "雖然佢識砌啲機械模型嚟玩，但係讀書讀得好慢"
-    );
-    assert_eq!(
-        iter.next().unwrap(),
-        "可能係因為學習障礙病，又或者只係因為怕醜，又或者係因為佢個腦結構特殊"
-    );
+    assert_eq!(iter.next().unwrap(), "雖然佢識砌啲機械模型嚟玩");
+    assert_eq!(iter.next().unwrap(), "但係讀書讀得好慢");
+    assert_eq!(iter.next().unwrap(), "可能係因為學習障礙病");
+    assert_eq!(iter.next().unwrap(), "又或者只係因為怕醜");
+    assert_eq!(iter.next().unwrap(), "又或者係因為佢個腦結構特殊");
     assert_eq!(
         iter.next().unwrap(),
         "最新嘅理論話愛因斯坦應該係患咗亞氏保加症"
     );
     assert_eq!(iter.next().unwrap(), "係自閉症嘅一種");
-    assert_eq!(
-        iter.next().unwrap(),
-        "因為當時呢個病未畀人發現，佢父母重以為佢係低能"
-    );
-    assert_eq!(
-        iter.next().unwrap(),
-        "愛因斯坦話自己之所以諗得出相對論，正係因為細個時學嘢慢"
-    );
-    assert_eq!(
-        iter.next().unwrap(),
-        "遲過其他小朋友開始思索時空，到嗰陣思想已經比較成熟"
-    );
-    assert_eq!(iter.next().unwrap(), "後來佢又寫咗好多有關時空，物質嘅理論");
-    assert_eq!(
-        iter.next().unwrap(),
-        "不過，因為當時嘅人睇唔明佢嘅理論，導致佢無法得到應有嘅尊重"
-    );
-    assert_eq!(iter.next().unwrap(), "但至今，重有好多都睇唔明佢寫乜");
-    assert_eq!(
-        iter.next().unwrap(),
-        "不過，最大唔同嘅係，人已經尊重佢，而唔係當佢癲佬"
-    );
+    assert_eq!(iter.next().unwrap(), "因為當時呢個病未畀人發現");
+    assert_eq!(iter.next().unwrap(), "佢父母重以為佢係低能");
+    assert_eq!(iter.next().unwrap(), "愛因斯坦話自己之所以諗得出相對論");
+    assert_eq!(iter.next().unwrap(), "正係因為細個時學嘢慢");
+    assert_eq!(iter.next().unwrap(), "遲過其他小朋友開始思索時空");
+    assert_eq!(iter.next().unwrap(), "到嗰陣思想已經比較成熟");
+    assert_eq!(iter.next().unwrap(), "因為佢成功發現光電效應");
+    assert_eq!(iter.next().unwrap(), "後來佢又寫咗好多有關時空");
+    assert_eq!(iter.next().unwrap(), "物質嘅理論");
+    assert_eq!(iter.next().unwrap(), "因為當時嘅人睇唔明佢嘅理論");
+    assert_eq!(iter.next().unwrap(), "導致佢無法得到應有嘅尊重");
+    assert_eq!(iter.next().unwrap(), "佢嘅理論");
+    assert_eq!(iter.next().unwrap(), "先有人開始明白少少");
+    assert_eq!(iter.next().unwrap(), "但至今");
+    assert_eq!(iter.next().unwrap(), "重有好多都睇唔明佢寫乜");
+    assert_eq!(iter.next().unwrap(), "最大唔同嘅係");
+    assert_eq!(iter.next().unwrap(), "人已經尊重佢");
+    assert_eq!(iter.next().unwrap(), "而唔係當佢癲佬");
     assert!(iter.next().is_none());
 }
 
@@ -75,8 +68,9 @@ fn test_extractor_with_bondary_condition() {
     let mut iter = builder.build(texts[0].as_str());
     assert_eq!(iter.next().unwrap(), "春");
     assert_eq!(iter.next().unwrap(), "多");
-    assert_eq!(iter.next().unwrap(), "玉");
-    assert_eq!(iter.next().unwrap(), "砌");
+    assert_eq!(iter.next().unwrap(), "國");
+    assert_eq!(iter.next().unwrap(), "玉？");
+    assert_eq!(iter.next().unwrap(), "砌！");
     assert!(iter.next().is_none());
 }
 
@@ -84,23 +78,22 @@ fn test_extractor_with_bondary_condition() {
 fn test_extractor_with_ignore_symbols() {
     let texts = load(&PathBuf::from("src/test_data/wiki_02")).unwrap();
     let ignore_symbols = vec!['「', '」'];
-    let mut builder = SentenceExtractorBuilder::new()
-        .ignore_symbols(&ignore_symbols)
-        .unwrap();
+    let mut builder = SentenceExtractorBuilder::new().ignore_symbols(&ignore_symbols);
     let mut iter = builder.build(texts[0].as_str());
 
     assert_eq!(iter.next().unwrap(), "噬魂師係由大久保篤創作嘅日本漫畫作品");
+    assert_eq!(iter.next().unwrap(), "舞台為死神武器工匠專門學校");
+    assert_eq!(iter.next().unwrap(), "俗稱死武專");
+    assert_eq!(iter.next().unwrap(), "呢間學校係專門培育工匠同武器");
+    assert_eq!(iter.next().unwrap(), "工匠同武器係一對嘅");
     assert_eq!(
         iter.next().unwrap(),
-        "舞台為死神武器工匠專門學校，俗稱死武專"
+        "工匠同武器嘅靈魂波長配合會令到戰鬥力提高"
     );
+    assert_eq!(iter.next().unwrap(), "工匠參與實戰");
     assert_eq!(
         iter.next().unwrap(),
-        "工匠同武器係一對嘅，工匠同武器嘅靈魂波長配合會令到戰鬥力提高"
-    );
-    assert_eq!(
-        iter.next().unwrap(),
-        "工匠參與實戰，武器則會變化成自己擅長形態嘅武器支援工匠"
+        "武器則會變化成自己擅長形態嘅武器支援工匠"
     );
     assert_eq!(iter.next().unwrap(), "武器可以控制同支援工匠靈魂波長嘅增強");
     assert_eq!(iter.next().unwrap(), "工匠就擁有探測靈魂種類同位置");
@@ -108,48 +101,17 @@ fn test_extractor_with_ignore_symbols() {
 }
 
 #[test]
-fn test_extractor_handle_ignore_symbol_conflict() {
-    let ignore_symbols = vec!['，'];
-    let builder = SentenceExtractorBuilder::new().ignore_symbols(&ignore_symbols);
-    assert!(builder.is_err());
-    if let Err(e) = builder {
-        assert_eq!(
-            e.to_string(),
-            "Options conflict: '，' is used to determine the cuting point for sentance".to_string()
-        );
-    }
-}
-
-#[test]
-fn test_extractor_handle_auxiliary_symbol_conflict() {
-    let ignore_symbols = vec!['「', '」', '＃'];
-    let mut auxiliary_symbols = vec!['＃', '；', '：'];
-    let builder = SentenceExtractorBuilder::new()
-        .ignore_symbols(&ignore_symbols)
-        .unwrap()
-        .auxiliary_symbols(&mut auxiliary_symbols);
-    assert!(builder.is_err());
-    if let Err(e) = builder {
-        assert_eq!(
-            e.to_string(),
-            "Options conflict: '＃' is ignored".to_string()
-        );
-    }
-}
-
-#[test]
 fn test_extractor_with_ending_symbols() {
     let texts = load(&PathBuf::from("src/test_data/wiki_01")).unwrap();
-    let mut builder = SentenceExtractorBuilder::new().chop_ending_symbol(false);
-
+    let mut builder = SentenceExtractorBuilder::new();
     let mut iter = builder.build(texts[0].as_str());
-    assert_eq!(iter.next().unwrap(), "春，花秋，月何時，了往事知。");
-    assert_eq!(iter.next().unwrap(), "樓昨夜。");
-    assert_eq!(iter.next().unwrap(), "又東風故。");
-    assert_eq!(iter.next().unwrap(), "國、不堪、回首月、明中雕欄。");
-    assert_eq!(
-        iter.next().unwrap(),
-        "應在「只」是《朱》顏：改『問』君【能】有…幾—多．愁；"
-    );
+    assert_eq!(iter.next().unwrap(), "月何時");
+    assert_eq!(iter.next().unwrap(), "了往事知");
+    assert_eq!(iter.next().unwrap(), "樓昨夜");
+    assert_eq!(iter.next().unwrap(), "又東風故");
+    assert_eq!(iter.next().unwrap(), "回首月");
+    assert_eq!(iter.next().unwrap(), "明中雕欄");
+    assert_eq!(iter.next().unwrap(), "應在「只」是《朱》顏");
+    assert_eq!(iter.next().unwrap(), "改『問』君【能】有…幾—多．愁");
     assert!(iter.next().is_none());
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7,9 +7,10 @@ fn test_extractor() {
     let mut builder = SentenceExtractorBuilder::new();
     let mut iter = builder.build(texts[0].as_str());
 
-    assert_eq!(iter.next().unwrap(), "愛因斯坦（");
+    assert_eq!(iter.next().unwrap(), "愛因斯坦");
     assert_eq!(iter.next().unwrap(), "全名音譯");
     assert_eq!(iter.next().unwrap(), "阿爾拔·愛因斯坦");
+    assert_eq!(iter.next().unwrap(), "係一位理論物理學家");
     assert_eq!(iter.next().unwrap(), "佢最出名嘅係發表咗相對論");
     assert_eq!(iter.next().unwrap(), "另外喺量子力學");
     assert_eq!(iter.next().unwrap(), "統計力學");
@@ -71,6 +72,8 @@ fn test_extractor_with_bondary_condition() {
     assert_eq!(iter.next().unwrap(), "國");
     assert_eq!(iter.next().unwrap(), "玉？");
     assert_eq!(iter.next().unwrap(), "砌！");
+    assert_eq!(iter.next().unwrap(), "應");
+    assert_eq!(iter.next().unwrap(), "猶");
     assert!(iter.next().is_none());
 }
 
@@ -81,7 +84,8 @@ fn test_extractor_with_ignore_symbols() {
     let mut builder = SentenceExtractorBuilder::new().ignore_symbols(&ignore_symbols);
     let mut iter = builder.build(texts[0].as_str());
 
-    assert_eq!(iter.next().unwrap(), "噬魂師係由大久保篤創作嘅日本漫畫作品");
+    assert_eq!(iter.next().unwrap(), "噬魂師");
+    assert_eq!(iter.next().unwrap(), "係由大久保篤創作嘅日本漫畫作品");
     assert_eq!(iter.next().unwrap(), "舞台為死神武器工匠專門學校");
     assert_eq!(iter.next().unwrap(), "俗稱死武專");
     assert_eq!(iter.next().unwrap(), "呢間學校係專門培育工匠同武器");
@@ -111,7 +115,7 @@ fn test_extractor_with_ending_symbols() {
     assert_eq!(iter.next().unwrap(), "又東風故");
     assert_eq!(iter.next().unwrap(), "回首月");
     assert_eq!(iter.next().unwrap(), "明中雕欄");
-    assert_eq!(iter.next().unwrap(), "應在「只」是《朱》顏");
+    assert_eq!(iter.next().unwrap(), "在「只」是《朱》顏");
     assert_eq!(iter.next().unwrap(), "改『問』君【能】有…幾—多．愁");
     assert!(iter.next().is_none());
 }

--- a/src/extractor/error.rs
+++ b/src/extractor/error.rs
@@ -1,8 +1,4 @@
 //! Error management of extractor
-use failure_derive::*;
 
-#[derive(Fail, Debug)]
-pub enum Error {
-    #[fail(display = "Options conflict: {}", 0)]
-    OptionsConflic(String),
-}
+#[derive(Debug)]
+pub enum Error {}

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -9,7 +9,7 @@ use crate::standard_characters::STANDARD_CHARACTERS;
 mod error;
 
 static SHOWUP_PUNCTUATIONS: [char; 2] = ['？', '！'];
-static TERMINAL_PUNCTUATIONS: [char; 8] = ['，', '。', '、', '：', '？', '；', '！', '\n'];
+static TERMINAL_PUNCTUATIONS: [char; 10] = ['（', '）', '，', '。', '、', '：', '？', '；', '！', '\n'];
 static PUNCTUATIONS: [char; 37] = [
     '"', '"', '、', '‧', '—', '—', '—', '～', '“', '”', '；', '·', '：', '‘', '•', '─', '兀', '︰',
     '︿', '﹀', '，', '、', '．', '；', '：', '＃', '＆', '＊', '＋', '－', '＜', '＞', '＝', '＄',


### PR DESCRIPTION
used predefined cutting symbols & show `？` or `！`

- cutting sentence with these symbols `，`, `。`, `、`, `：`, `？`, `；`, `！`, `（` & `）`
- show the ending symbol if it is `？` or `！`
- cancel auxiliary symbols, chopping the ending symbol features
- update testcase
- update readme
- ref: https://github.com/mozillahk/cv-sentence-extractor/pull/10, https://github.com/mozillahk/cv-sentence-extractor/pull/11
