### PR TITLE
Add rules and blockwords for Lithuanian language --full-wiki-extraction=lt

### DIFF
--- a/src/rules/lt.toml
+++ b/src/rules/lt.toml
@@ -20,9 +20,11 @@ disallowed_symbols = [
 ]
 abbreviation_patterns = [
 	"[A-ZĄČĘĖĮŠŲŪŽ]+\\.",
-	"[A-Z]+\\.*[A-Z]",
+	"[A-ZĄČĘĖĮŠŲŪŽ]+\\.*[A-ZĄČĘĖĮŠŲŪŽ]",
+	# for UAB, LŽS and similar
+	"[A-ZĄČĘĖĮŠŲŪŽ]{2,}",
 	# coommon abbr
-	"kt\\.|pr\\.|[Vv]yr\\.|[Mm]ot\\.|žr\\.|Šv\\.|[Šš]vč\\.|mėn\\.|el\\.|Dž\\.|įv\\.|dab\\.|gel\\.|ež\\.|[Nn]r\\.",
+	"kt\\.|pr\\.|[Vv]yr\\.|[Mm]ot\\.|žr\\.|Šv\\.|[Šš]vč\\.|mėn\\.|el\\.|Dž\\.|įv\\.|dab\\.|gel\\.|ež\\.|[Nn]r\\.|I\\s",
 	# chemical elements?
 	"Cl"
 ]

--- a/src/rules/lt.toml
+++ b/src/rules/lt.toml
@@ -1,0 +1,28 @@
+allowed_symbols_regex="[A-Za-ząčęėįšųūžĄČĘĖĮŠŲŪŽ‚–\\. \"„“]"
+matching_symbols = [["„", "“"]]
+min_trimmed_length = 6
+min_word_count = 3
+max_word_count = 14
+min_characters = 1
+may_end_with_colon = false
+quote_start_with_letter = true
+needs_punctuation_end = true
+needs_letter_start = true
+needs_uppercase_start = true
+broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;"]
+disallowed_symbols = [
+  '<', '>', '+', '*', '\', '#', '@', '^', '[', ']', '(', ')', '/',
+  'é', 'è', 'à', 'ç', 'Å',
+  'α', 'β', 'Γ', 'γ', 'Δ', 'δ', 'ε', 'ζ', 'η', 'Θ', 'θ', 'ι', 'κ',
+  'Λ', 'λ', 'μ', 'ν', 'Ξ', 'ξ', 'Π', 'π', 'ρ', 'Σ', 'σ', 'ς', 'τ',
+  'υ', 'Φ', 'φ', 'χ', 'Ψ', 'ψ', 'Ω', 'ω',
+  '«', '»', '”', 'º', '&'
+]
+abbreviation_patterns = [
+	"[A-ZĄČĘĖĮŠŲŪŽ]+\\.",
+	"[A-Z]+\\.*[A-Z]",
+	# coommon abbr
+	"kt\\.|pr\\.|[Vv]yr\\.|[Mm]ot\\.|žr\\.|Šv\\.|[Šš]vč\\.|mėn\\.|el\\.|Dž\\.|įv\\.|dab\\.|gel\\.|ež\\.|[Nn]r\\.",
+	# chemical elements?
+	"Cl"
+]


### PR DESCRIPTION
**How many sentences did you get at the end?**
~130 000

**How did you create the blacklist file?**
As described in readme. Filtering out works frequency 10 and less. After manually inspecting it I noticed really great words, that should not be blocked.
I'm not sure if I should reduce it more?
Going manually over 900 000 entries doesn't seem like a productive way to spend time, especially if it might be regenerated next time by someone else.

**Get at least 3 different native speakers (ideally linguistics) to review a random sample of 100-500 sentences and estimate the average error ratio and comment (or link their comment) in the PR.**

Created 4 random samples of 200 sentences: `shuf -n 200 -o sample.txt wiki.lt.txt`

Made a document with those samples. I'll review one and share others with native speakers (I even might find linguists): [Google Sheet Document](https://docs.google.com/spreadsheets/d/1sduhQ-oUbpeSzJORsgizL3_xBhtpIdcbrhodx4xMDh4/edit?usp=sharing)
I'll also discuss if the blacklist file could be improved.