### PR TITLE
Fix regex rules in hu.toml

### DIFF
--- a/src/rules/hu.toml
+++ b/src/rules/hu.toml
@@ -7,7 +7,7 @@ quote_start_with_letter = true
 needs_punctuation_end = false
 needs_letter_start = true
 needs_uppercase_start = true
-allowed_symbols_regex = "[0-9A-Za-záÁéÉíÍóÓöÖőŐúÚüÜ„“‚‘’\\- –\\.\\?!]"
+allowed_symbols_regex = "[0-9A-Za-záÁéÉíÍóÓöÖőŐúÚüÜűŰ„“‚‘’\\- –\\.\\?!]"
 disallowed_symbols = []
 broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;"]
 
@@ -16,10 +16,10 @@ matching_symbols = [
 ]
 
 abbreviation_patterns = [
-  "[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚVWXYZ]\\.|[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚVWXYZ]{2,}|Várm\\.|ún\\.|ref\\.|kir\\.|[Rr]\\. kath\\.|róm\\.|vm\\.|stb\\.|ill\\.|pl\\.|Bt\\.|Kft\\.|Kht\\.|vhr\\.|tsz\\.|u\\.|hsz\\.|ifj\\.|gk\\.|jan\\.|feb\\.|márc\\.|máj\\.|ápr\\.|jún\\.|júl\\.|aug\\.|szept\\.|okt\\.|nov\\.|dec\\.|közt\\.|min\\.|max\\.|[Oo]rsz\\.|id\\.|Zrt\\.|Nyrt\\.|Rt\\.|KKT\\.|Mo\\.|Bp\\.|Özv\\.|Korm\\.|Kr\\.|Kr\\. ?e\\.|Kr\\. ?u\\.|[MDCLXVI]+\\.|BSc\\.|MSc\\.|Dr\\.|Phd\\.|ltp\\.|vb\\.|km\\.|nm\\.|dm\\.|mg\\.|KW\\.|W\\.|kb\\.|sz\\." ,
+  "[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚÜŰVWXYZ]\\.|[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚÜŰVWXYZ]{2,}|Várm\\.|ún\\.|ref\\.|kir\\.|[Rr]\\. kath\\.|róm\\.|vm\\.|stb\\.|ill\\.|pl\\.|Bt\\.|Kft\\.|Kht\\.|vhr\\.|tsz\\.|u\\.|hsz\\.|ifj\\.|gk\\.|jan\\.|feb\\.|márc\\.|máj\\.|ápr\\.|jún\\.|júl\\.|aug\\.|szept\\.|okt\\.|nov\\.|dec\\.|közt\\.|min\\.|max\\.|[Oo]rsz\\.|id\\.|Zrt\\.|Nyrt\\.|Rt\\.|KKT\\.|Mo\\.|Bp\\.|Özv\\.|Korm\\.|Kr\\.|Kr\\. ?e\\.|Kr\\. ?u\\.|[MDCLXVI]+\\.|BSc\\.|MSc\\.|Dr\\.|Phd\\.|ltp\\.|vb\\.|km\\.|nm\\.|dm\\.|mg\\.|KW\\.|W\\.|kb\\.|sz\\." ,
 ]
 
 other_patterns = [
-  "[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚVWXYZ]-",
+  "[AÁBCDEÉFGHIÍJKLMNOÓÖŐPQRSTUÚÜŰVWXYZ]-",
   "\\s-",
 ]


### PR DESCRIPTION
"ű" and "Ű" are also valid Hungarian letters.

Source: Rules of Hungarian Orthography, 12th edition (AkH.12), section 4. and section 10.