### PR TITLE
Adjust all cargo run commands to use release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python WikiExtractor.py --json ../enwiki-latest-pages-articles-multistream.xml
 
 ```bash
 cd ../cv-sentence-extractor
-cargo run -- extract -l en -d ../wikiextractor/text/ >> wiki.en.txt
+cargo run --release -- extract -l en -d ../wikiextractor/text/ >> wiki.en.txt
 ```
 
 *Tip: You don't need this last process to finish to start observing the output, wiki.en.txt should get a few thousands sentences in just a few minutes, and you can use that as a way to estimate the quality of the output early on and stop the process if you are not happy.*
@@ -91,7 +91,7 @@ python WikiExtractor.py --json ../enwikisource-latest-pages-articles.xml
 
 ```bash
 cd ../cv-sentence-extractor
-cargo run -- extract-wikisource -l en -d ../wikiextractor/text/ >> wiki.en.txt
+cargo run --release -- extract-wikisource -l en -d ../wikiextractor/text/ >> wiki.en.txt
 ```
 
 *Tip: You don't need this last process to finish to start observing the output, wiki.en.txt should get a few thousands sentences in just a few minutes, and you can use that as a way to estimate the quality of the output early on and stop the process if you are not happy.*
@@ -99,12 +99,6 @@ cargo run -- extract-wikisource -l en -d ../wikiextractor/text/ >> wiki.en.txt
 ### Extract from line break separated files
 
 If you have one or multiple files with one sentence per line, you can use this extractor to extract sentences from these files applying the defined language rules. This can be useful if you have a large list of sentences and you want to only have sentences which match the rules.
-
-```
-cargo run -- extract-file -l en -d ../texts/ >> file.en.txt
-```
-
-If the performance is poor, try release build:
 
 ```
 cargo run --release -- extract-file -l en -d ../texts/ >> file.en.txt
@@ -193,7 +187,7 @@ After running step 1 and 2 from the `Usage` section above, run:
 
 ```bash
 cd ../cv-sentence-extractor
-cargo run -- extract -l en -d ../wikiextractor/text/ --no_check >> wiki.en.all.txt
+cargo run --release -- extract -l en -d ../wikiextractor/text/ --no_check >> wiki.en.all.txt
 ```
 
 Then you can use the cvtools scripts to generate a list of the word frequency:

--- a/scripts/providers/wiki-source.sh
+++ b/scripts/providers/wiki-source.sh
@@ -30,7 +30,7 @@ function extract {
   python $WIKI_EXTRACTOR_PATH --processes 4 --json $DUMP_FILE
 
   echo "Running extraction"
-  cargo run -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH >> $EXTRACTED_SENTENCES_PATH
+  cargo run --release -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH >> $EXTRACTED_SENTENCES_PATH
 }
 
 function cleanup {

--- a/scripts/providers/wiki.sh
+++ b/scripts/providers/wiki.sh
@@ -35,9 +35,9 @@ function extract {
 
   echo "Running extraction"
   if [ $TYPE == "blocklist" ]; then
-    cargo run -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH --no_check >> $EXTRACTED_SENTENCES_PATH
+    cargo run --release -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH --no_check >> $EXTRACTED_SENTENCES_PATH
   else
-    cargo run -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH >> $EXTRACTED_SENTENCES_PATH
+    cargo run --release -- extract -l $LANGUAGE_CODE -d $EXTRACTED_TEXT_PATH >> $EXTRACTED_SENTENCES_PATH
   fi
 }
 


### PR DESCRIPTION
By inspiration of @somerandomguyontheweb and the PR #148 I've run a performance measurement with Wikipedia as well. There is a big increase in that performance as well when using a release build, which really is not that surprising and I should have done that a long time ago. The pipelines now use a release build as well.

Thanks @somerandomguyontheweb for noticing this!