### PR TITLE
Improvement for best practices for EN rules file (fixes #156)

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -458,9 +458,9 @@ mod test {
     #[test]
     fn test_english() {
         let rules : Rules = load_rules("en");
-        
+
         assert!(check(&rules, &String::from("This is absolutely valid.")));
-        assert!(check(&rules, &String::from("this is lowercase")));
+        assert!(!check(&rules, &String::from("this is lowercase")));
         assert!(!check(&rules, &String::from("")));
         assert!(!check(&rules, &String::from("\"😊")));
         assert!(!check(&rules, &String::from("This ends with:")));

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -31,3 +31,17 @@ other_patterns = [
   "(\\s[A-Za-z]{1}[\\.|\\?|!]*$)|\\s[A-Za-z]{1}\\s",
   "[a-z][A-Z][a-z]",
 ]
+
+# Replacements
+
+replacements = [
+  ["e.g.", "for example"],
+  ["E.g.", "For example"],
+  ["i.e.", "that is"],
+  ["I.e.", "That is"],
+  ["Mr.", "Mister"],
+  ["Ms.", "Miss"],
+  ["Prof.", "Professor"],
+  ["Dr.", "Doctor"],
+  ["a.k.a.", "also known as"],
+]

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -1,3 +1,19 @@
+
+# Replacements which are run before sentences are split
+replacements = [
+  ["e.g.", "for example"],
+  ["E.g.", "For example"],
+  ["i.e.", "that is"],
+  ["I.e.", "That is"],
+  ["Mr.", "Mister"],
+  ["Ms.", "Miss"],
+  ["Prof.", "Professor"],
+  ["Dr.", "Doctor"],
+  ["a.k.a.", "also known as"],
+  ["et al.", "and others"],
+  ["No.", "number"],
+]
+
 min_trimmed_length = 3
 min_word_count = 1
 max_word_count = 14
@@ -30,20 +46,4 @@ other_patterns = [
   "[\\.|\\?|!].+$",
   "(\\s[A-Za-z]{1}[\\.|\\?|!]*$)|\\s[A-Za-z]{1}\\s",
   "[a-z][A-Z][a-z]",
-]
-
-# Replacements
-
-replacements = [
-  ["e.g.", "for example"],
-  ["E.g.", "For example"],
-  ["i.e.", "that is"],
-  ["I.e.", "That is"],
-  ["Mr.", "Mister"],
-  ["Ms.", "Miss"],
-  ["Prof.", "Professor"],
-  ["Dr.", "Doctor"],
-  ["a.k.a.", "also known as"],
-  ["et al.", "and others"],
-  ["No.", "number"],
 ]

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -22,4 +22,12 @@ abbreviation_patterns = [
   "[A-Z]+\\.*[A-Z]"
 ]
 
-other_patterns = []
+# Other patterns
+#   - Sentence delimiter can only be at the end of a sentence
+#   - No words with only one letter (" a.", " a", " a ")
+#   - Mixed upper/lowercase in words (LaSi - mostly chemical elements?)
+other_patterns = [
+  "[\\.|\\?|!].+$",
+  "(\\s[A-Za-z]{1}[\\.|\\?|!]*$)|\\s[A-Za-z]{1}\\s",
+  "[a-z][A-Z][a-z]",
+]

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -16,6 +16,8 @@ matching_symbols = [
   ["(", ")"]
 ]
 
+# Abbreviation examples for each regex
+#   - A.B or FBI
 abbreviation_patterns = [
   "[A-Z]+\\.*[A-Z]"
 ]

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -1,18 +1,23 @@
 min_trimmed_length = 3
 min_word_count = 1
 max_word_count = 14
-min_characters = 0
+min_characters = 1
 may_end_with_colon = false
 quote_start_with_letter = true
 needs_punctuation_end = false
 needs_letter_start = true
 needs_uppercase_start = false
-disallowed_symbols = [
-  '<', '>', '+', '*', '\', '#', '@', '^', '[', ']', '(', ')', '/',
-  'é', 'è', 'à', 'ç', 'Å',
-  'α', 'β', 'Γ', 'γ', 'Δ', 'δ', 'ε', 'ζ', 'η', 'Θ', 'θ', 'ι', 'κ',
-  'Λ', 'λ', 'μ', 'ν', 'Ξ', 'ξ', 'Π', 'π', 'ρ', 'Σ', 'σ', 'ς', 'τ',
-  'υ', 'Φ', 'φ', 'χ', 'Ψ', 'ψ', 'Ω', 'ω',
-]
 broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;"]
-abbreviation_patterns = ["[A-Z]+\\.*[A-Z]"]
+
+allowed_symbols_regex = "[\u0020A-Za-z\"„“‚‘’–\\.?!()]"
+even_symbols = ['"']
+matching_symbols = [
+  ["„", "“"],
+  ["(", ")"]
+]
+
+abbreviation_patterns = [
+  "[A-Z]+\\.*[A-Z]"
+]
+
+other_patterns = []

--- a/src/rules/en.toml
+++ b/src/rules/en.toml
@@ -6,7 +6,7 @@ may_end_with_colon = false
 quote_start_with_letter = true
 needs_punctuation_end = false
 needs_letter_start = true
-needs_uppercase_start = false
+needs_uppercase_start = true
 broken_whitespace = ["  ", " ,", " .", " ?", " !", " ;"]
 
 allowed_symbols_regex = "[\u0020A-Za-z\"„“‚‘’–\\.?!()]"
@@ -44,4 +44,6 @@ replacements = [
   ["Prof.", "Professor"],
   ["Dr.", "Doctor"],
   ["a.k.a.", "also known as"],
+  ["et al.", "and others"],
+  ["No.", "number"],
 ]


### PR DESCRIPTION
This uses best practices learned over the past 2 years or so. As English often gets copied, we for example want to use allowed_symbols.

See #156 for the discussions around this.