### PR TITLE
Test only: remove abbreviation rules to test rust-punkt behavior

### DIFF
--- a/src/rules/de.toml
+++ b/src/rules/de.toml
@@ -15,22 +15,3 @@ matching_symbols = [
   ["„", "“"]
 ]
 
-# Abbreviation examples for each regex, also cheating a bit and adding more regex which has nothing to do with abbreviations:
-#   - A.B or z.B.
-#   - bzw. / ca. / gem. / v. Chr. / n. Chr. / sog. / Co. (Remy & Co.) / Art. (Art. drei des Bundesgesetzes) / and other abbreviations that could end up at the end of a sentence
-abbreviation_patterns = [
-  "[A-Z]+\\.*[A-Z]",
-  "bzw\\.|ca\\.|gem\\.|[v|n]\\.\\sChr\\.|sog\\.|Co\\.|Art\\.|geb\\.|hl\\.|int\\.|allg\\.|bes\\.|bez\\.|eigtl\\.|gegr\\.|ugs\\.|urspr\\.|usw\\.|zz\\.",
-]
-
-# Other patterns
-#   - Jahrhundert and others at the beginning of the sentence (circumvents wrongly splitted sentences from WikiExtractor such as "Im 3. Jahrhundert begann ..." leading to two incomplete sentences)
-#   - Sentence delimiter can only be at the end of a sentence
-#   - No words with only one letter (" a.", " a", " a ", "a ")
-#   - Mixed upper/lowercase in words (LaSi - mostly chemical elements?)
-other_patterns = [
-  "^(Jahrhundert|Liga|Bundesliga|Klasse)",
-  "[\\.|\\?|!].+$",
-  "(\\s[A-Za-z]{1}[\\.|\\?|!]*$)|(^[A-Za-z]{1}\\s)|\\s[A-Za-z]{1}\\s",
-  "[a-z][A-Z][a-z]",
-]


### PR DESCRIPTION
Please ignore this, this is solely used to get a sample extract with rust-punkt without any abbreviation and pattern rules. I will close it once done.

(Yes, in a perfect world I would have a manual trigger that starts a sample extraction on a given branch so I don't need to create a PR. If you read this and want to implement that, happy to help!)