### PR TITLE
Add a new rule - stem_separator_regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The following rules can be configured per language. Add a `<language>.toml` file
 | needs_punctuation_end |  If a sentence needs to end with a punctuation | boolean | false
 | needs_uppercase_start |  If a sentence needs to start with an uppercase | boolean | false
 | other_patterns |  Regex to disallow anything else | Rust Regex Array | all other patterns allowed
+| stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""
 | quote_start_with_letter |  If a quote needs to start with a letter | boolean | true
 | replacements |  Replaces abbreviations or other words according to configuration. This happens before any other rules are checked. | Array of replacement configurations: each configuration is an Array of two values: `["search", "replacement"]`. See example below. | nothing gets replaced
 | segmenter |  Segmenter to use for this language. See below for more information. | "python" | using `rust-punkt` by default

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ The following rules can be configured per language. Add a `<language>.toml` file
 | needs_punctuation_end |  If a sentence needs to end with a punctuation | boolean | false
 | needs_uppercase_start |  If a sentence needs to start with an uppercase | boolean | false
 | other_patterns |  Regex to disallow anything else | Rust Regex Array | all other patterns allowed
-| stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""
 | quote_start_with_letter |  If a quote needs to start with a letter | boolean | true
 | replacements |  Replaces abbreviations or other words according to configuration. This happens before any other rules are checked. | Array of replacement configurations: each configuration is an Array of two values: `["search", "replacement"]`. See example below. | nothing gets replaced
 | segmenter |  Segmenter to use for this language. See below for more information. | "python" | using `rust-punkt` by default
+| stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""
 
 ### Example for `matching_symbols`
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -63,9 +63,9 @@ pub fn check(rules: &Rules, raw: &str) -> bool {
         let mut stems_words: Vec<&str> = vec![];
         
         for word in words {
-            let maybe_stem_word: &str = &(regex.split(word).nth(0).unwrap_or(word));
+            let maybe_stem_word: &str = regex.split(word).next().unwrap_or(word);
             if maybe_stem_word != word {
-                stems_words.push(&maybe_stem_word);
+                stems_words.push(maybe_stem_word);
             }
         }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -58,19 +58,18 @@ pub fn check(rules: &Rules, raw: &str) -> bool {
         return false;
     }
 
-    if !rules.stem_separator_regex.is_empty() && !(rules.stem_separator_regex == "[]") {
+    if !rules.stem_separator_regex.is_empty() {
         let regex: Regex = Regex::new(&rules.stem_separator_regex).unwrap();
         let mut stems_words: Vec<&str> = vec![];
         
         for word in words {
-            let maybe_stem_word: &str;
-            maybe_stem_word = &(regex.split(word).nth(0).unwrap_or(word));
+            let maybe_stem_word: &str = &(regex.split(word).nth(0).unwrap_or(word));
             if maybe_stem_word != word {
                 stems_words.push(&maybe_stem_word);
             }
         }
 
-        if stems_words.clone().into_iter().any( |word| rules.disallowed_words.contains(word))
+        if stems_words.into_iter().any(|word| rules.disallowed_words.contains(word))
         {
             return false;
         }
@@ -333,11 +332,10 @@ mod test {
         assert!(!check(&rules, &String::from("Washington DC's Mall has many musums.")));
 
         let rules : Rules = Rules {
-            stem_separator_regex: "[]".to_string(),
             disallowed_words: ["Smithsonian", "DC", "Museum"].iter().map(|s| (*s).to_string()).collect(),
             ..Default::default()
         };
-        assert!(check(&rules, &String::from("Smithsonian's venues are in DC's Mall will not be checked for stem words.")));
+        assert!(check(&rules, &String::from("Smithsonian's venues are in DC's Mall - this will not be checked for stem words.")));
 
 
     }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -63,14 +63,13 @@ pub fn check(rules: &Rules, raw: &str) -> bool {
         let mut stems_words: Vec<&str> = vec![];
         
         for word in words {
-            let maybe_stem_word: &str = regex.split(word).next().unwrap_or(word);
+            let maybe_stem_word = regex.split(word).next().unwrap_or(word);
             if maybe_stem_word != word {
                 stems_words.push(maybe_stem_word);
             }
         }
 
-        if stems_words.into_iter().any(|word| rules.disallowed_words.contains(word))
-        {
+        if stems_words.into_iter().any(|word| rules.disallowed_words.contains(word)) {
             return false;
         }
     }
@@ -335,9 +334,7 @@ mod test {
             disallowed_words: ["Smithsonian", "DC", "Museum"].iter().map(|s| (*s).to_string()).collect(),
             ..Default::default()
         };
-        assert!(check(&rules, &String::from("Smithsonian's venues are in DC's Mall - this will not be checked for stem words.")));
-
-
+        assert!(check(&rules, &String::from("Smithsonian's venues are in DC's Mall - no check for stems.")));
     }
 
     #[test]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -47,15 +47,33 @@ pub fn check(rules: &Rules, raw: &str) -> bool {
         return false;
     }
 
-    let mut words = trimmed.split_whitespace();
+    let words = trimmed.split_whitespace();
     let word_count = words.clone().count();
     if word_count < rules.min_word_count
         || word_count > rules.max_word_count
-        || words.any(|word| rules.disallowed_words.contains(
+        || words.clone().any(|word| rules.disallowed_words.contains(
              &word.trim_matches(|c: char| !c.is_alphabetic()).to_lowercase()
            ))
     {
         return false;
+    }
+
+    if !rules.stem_separator_regex.is_empty() && !(rules.stem_separator_regex == "[]") {
+        let regex: Regex = Regex::new(&rules.stem_separator_regex).unwrap();
+        let mut stems_words: Vec<&str> = vec![];
+        
+        for word in words {
+            let maybe_stem_word: &str;
+            maybe_stem_word = &(regex.split(word).nth(0).unwrap_or(word));
+            if maybe_stem_word != word {
+                stems_words.push(&maybe_stem_word);
+            }
+        }
+
+        if stems_words.clone().into_iter().any( |word| rules.disallowed_words.contains(word))
+        {
+            return false;
+        }
     }
 
     let abbr = rules.abbreviation_patterns.iter().any(|pattern| {
@@ -299,6 +317,29 @@ mod test {
             ..Default::default()
         };
         assert!(!check(&rules, &String::from("This has a's")));
+    }
+
+    #[test]
+    fn test_stem_separator_regex() {
+        let rules : Rules = Rules {
+            stem_separator_regex: "[']".to_string(),
+            disallowed_words: ["Smithsonian", "DC", "Museum"].iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        };
+
+        assert!(check(&rules, &String::from("The Mall has many museums.")));
+        assert!(!check(&rules, &String::from("Smithsonian's venues are in the Mall.")));
+        assert!(!check(&rules, &String::from("Do you know Smithsonian's African American Museum's location?")));
+        assert!(!check(&rules, &String::from("Washington DC's Mall has many musums.")));
+
+        let rules : Rules = Rules {
+            stem_separator_regex: "[]".to_string(),
+            disallowed_words: ["Smithsonian", "DC", "Museum"].iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        };
+        assert!(check(&rules, &String::from("Smithsonian's venues are in DC's Mall will not be checked for stem words.")));
+
+
     }
 
     #[test]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -54,6 +54,7 @@ pub struct Rules {
     pub broken_whitespace: Array,
     pub abbreviation_patterns: Array,
     pub other_patterns: Array,
+    pub stem_separator_regex: String,
     pub replacements: Array,
     pub even_symbols: Array,
     pub matching_symbols: Array,
@@ -79,6 +80,7 @@ impl Default for Rules {
             broken_whitespace: vec![],
             abbreviation_patterns: vec![],
             other_patterns: vec![],
+            stem_separator_regex: String::from(""),
             replacements: vec![],
             even_symbols: vec![],
             matching_symbols: vec![],
@@ -114,6 +116,7 @@ mod test {
         assert_eq!(rules.broken_whitespace, vec![]);
         assert_eq!(rules.abbreviation_patterns, vec![]);
         assert_eq!(rules.other_patterns, vec![]);
+        assert_eq!(rules.stem_separator_regex, String::from(""));
         assert_eq!(rules.replacements, vec![]);
         assert_eq!(rules.even_symbols, vec![]);
         assert_eq!(rules.matching_symbols, vec![]);


### PR DESCRIPTION
This will mainly be useful for blacklisted proper names with suffixes. If you blacklist the stem word (e.g. a person's name) it should be enough.

If specified, the code splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. 

It is a simple regex of separators. For example, for apostrophes, you specify `stem_separator_regex = "[']"` in the rule file.

If you do not specify it, or set it to `= ""` or `= "[]"` it will not be triggered.

It works after the initial blacklist check is done and only checks stem words extracted with stem_separator_regex against the blacklist.
