### PR TITLE
Fix toolchain to nightly-2023-07-28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hecrj/setup-rust-action@50a120e4d34903c2c1383dec0e9b1d349a9cc2b1
         with:
-          rust-version: nightly
+          rust-version: nightly-2023-06-28
           components: clippy
       - name: Run clippy
         run: cargo clippy --all-targets --all-features
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/manual-dispatch-wikipedia-rerun.yml
+++ b/.github/workflows/manual-dispatch-wikipedia-rerun.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: [18.x]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       # SETUP

--- a/.github/workflows/manual-dispatch-wikipedia.yml
+++ b/.github/workflows/manual-dispatch-wikipedia.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       # SETUP

--- a/.github/workflows/manual-dispatch-wikisource.yml
+++ b/.github/workflows/manual-dispatch-wikisource.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       # SETUP

--- a/.github/workflows/manual-issue-trigger.yml
+++ b/.github/workflows/manual-issue-trigger.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       # SETUP

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly]
+        rust: [nightly-2023-06-28]
 
     steps:
       # SETUP

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2023-06-28


### PR DESCRIPTION
There seems to be an issue with the latest nightlies:

```
error[E0432]: unresolved import `proc_macro::LineColumn`     
 --> /home/mkohler/.cargo/registry/src/index.crates.io-6f17d22bba15001f/inline-python-macros-0.11.0/src/embed_python.rs:1:18
  |
1 | use proc_macro::{LineColumn, Span};                                                
  |                  ^^^^^^^^^^ no `LineColumn` in the root      
  |                                                                                    
  = help: consider importing this struct instead:         
          proc_macro2::LineColumn
                                                                                       
error[E0615]: attempted to take value of method `column` on type `proc_macro::Span`
  --> /home/mkohler/.cargo/registry/src/index.crates.io-6f17d22bba15001f/inline-python-macros-0.11.0/src/embed_python.rs:69:14
   |                                                                                   
69 |                     end_loc.column = end_loc.column.saturating_sub(end.len());
   |                             ^^^^^^ method, not a field
   |                                                                                   
   = help: methods are immutable and cannot be assigned to             

.....
```