### PR TITLE
Add rule to remove content between brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The following rules can be configured per language. Add a `<language>.toml` file
 | needs_uppercase_start |  If a sentence needs to start with an uppercase | boolean | false
 | other_patterns |  Regex to disallow anything else | Rust Regex Array | all other patterns allowed
 | quote_start_with_letter |  If a quote needs to start with a letter | boolean | true
-| remove_brackets_list |  Removes (possibly nested) user defined brackets and content inside them `(anything [else])` from the sentence before checking other rules | Array of matching brackets: each configuration is an Array of two values: `["opening_bracket", "closing_bracket"]`. See example below. | []
+| remove_brackets_list |  Removes (possibly nested) user defined brackets and content inside them `(anything [else])` from the sentence before replacements and checking other rules | Array of matching brackets: each configuration is an Array of two values: `["opening_bracket", "closing_bracket"]`. See example below. | []
 | replacements |  Replaces abbreviations or other words according to configuration. This happens before any other rules are checked. | Array of replacement configurations: each configuration is an Array of two values: `["search", "replacement"]`. See example below. | nothing gets replaced
 | segmenter |  Segmenter to use for this language. See below for more information. | "python" | using `rust-punkt` by default
 | stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""
@@ -209,7 +209,7 @@ remove_brackets_list = [
 ]
 ```
 
-This internally creates regex patterns `(.*)` and `[.*]` and removes them with their content, executed in given order.
+This internally creates related regex patterns and removes them with their content, executed in given order.
 
 ```
 Input: This (parantheses) (and this) will be removed also this one (another [one]) should.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The following rules can be configured per language. Add a `<language>.toml` file
 | needs_uppercase_start |  If a sentence needs to start with an uppercase | boolean | false
 | other_patterns |  Regex to disallow anything else | Rust Regex Array | all other patterns allowed
 | quote_start_with_letter |  If a quote needs to start with a letter | boolean | true
-| remove_parentheses |  Removes (possibly nested) parentheses and content inside them `(anything)` from the sentence before checking other rules | boolean | false
+| remove_brackets_list |  Removes (possibly nested) user defined brackets and content inside them `(anything [else])` from the sentence before checking other rules | Array of matching brackets: each configuration is an Array of two values: `["opening_bracket", "closing_bracket"]`. See example below. | []
 | replacements |  Replaces abbreviations or other words according to configuration. This happens before any other rules are checked. | Array of replacement configurations: each configuration is an Array of two values: `["search", "replacement"]`. See example below. | nothing gets replaced
 | segmenter |  Segmenter to use for this language. See below for more information. | "python" | using `rust-punkt` by default
 | stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""
@@ -198,6 +198,25 @@ Output: Valid
 
 Input: This is (a test))
 Output: Invalid
+```
+
+### Example for `remove_brackets_list`
+
+```
+remove_brackets_list = [
+  ["(", ")"],
+  ["[", "]"]
+]
+```
+
+This internally creates regex patterns `(.*)` and `[.*]` and removes them with their content, executed in given order.
+
+```
+Input: This (parantheses) (and this) will be removed also this one (another [one]) should.
+Output: This will be removed also this one should.
+
+Input: This is (malformed)) at the source.
+Output: This is ) at the source.
 ```
 
 ### Example for `replacements`

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The following rules can be configured per language. Add a `<language>.toml` file
 | needs_uppercase_start |  If a sentence needs to start with an uppercase | boolean | false
 | other_patterns |  Regex to disallow anything else | Rust Regex Array | all other patterns allowed
 | quote_start_with_letter |  If a quote needs to start with a letter | boolean | true
+| remove_parentheses |  Removes (possibly nested) parentheses and content inside them `(anything)` from the sentence before checking other rules | boolean | false
 | replacements |  Replaces abbreviations or other words according to configuration. This happens before any other rules are checked. | Array of replacement configurations: each configuration is an Array of two values: `["search", "replacement"]`. See example below. | nothing gets replaced
 | segmenter |  Segmenter to use for this language. See below for more information. | "python" | using `rust-punkt` by default
 | stem_separator_regex |  If given, splits words at the given characters to reach the stem words to check them again against the blacklist, e.g. prevents "Rust's" to pass if "Rust" is in the blacklist. | Simple regex of separators, e.g. for apostrophe `stem_separator_regex = "[']"` | ""

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -6,19 +6,9 @@ fn in_limit(x: usize, min_val: usize, max_val: usize) -> bool {
     x >= min_val && x <= max_val
 }
 
-fn maybe_remove_parentheses(rules: &Rules, line: &str) -> String {
-    if rules.remove_parentheses {
-        let regex = Regex::new("\\(.*\\)").unwrap();
-        let replaced = regex.replace_all(line, "").to_string();
-        return replaced.to_string().replace("  ", " ");
-    } else {
-        return line.to_string();
-    }
-}
-
 pub fn check(rules: &Rules, raw: &str) -> bool {
 
-    let trimmed: &str = &maybe_remove_parentheses(rules, raw.trim());
+    let trimmed: &str = raw.trim();
     
     let alpha_cnt = trimmed.chars().filter(|c| c.is_alphabetic()).count();
     if trimmed.len() < rules.min_trimmed_length
@@ -276,26 +266,6 @@ mod test {
 
         assert!(!check(&rules, &String::from("foo")));
         assert!(check(&rules, &String::from("Foo")));
-    }
-
-    #[test]
-    fn test_remove_parentheses() {
-        let mut rules : Rules = Rules {
-            remove_parentheses: false,
-            ..Default::default()
-        };
-
-        assert_eq!(maybe_remove_parentheses(&rules, &String::from("First (content) should stay.")), "First (content) should stay.");
-        assert_ne!(maybe_remove_parentheses(&rules, &String::from("Second (content) should stay.")), "Second should stay.");
-
-        rules = Rules {
-            remove_parentheses: true,
-            ..Default::default()
-        };
-
-        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Third (content) should be removed.")), "Third should be removed.");
-        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Fourth (content (and nested one)) should be removed.")), "Fourth should be removed.");
-        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Fifth [content (and nested one)] should partly be removed.")), "Fifth [content ] should partly be removed.");
     }
 
     #[test]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -10,10 +10,8 @@ fn maybe_remove_parentheses(rules: &Rules, line: &str) -> String {
     if rules.remove_parentheses {
         let regex = Regex::new("\\(.*\\)").unwrap();
         let replaced = regex.replace_all(line, "").to_string();
-        println!("PAREN REMOVED: {}", replaced.as_str().replace("  ", " "));
         return replaced.to_string().replace("  ", " ");
     } else {
-        println!("PAREN KEPT: {}", line);
         return line.to_string();
     }
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -7,9 +7,7 @@ fn in_limit(x: usize, min_val: usize, max_val: usize) -> bool {
 }
 
 pub fn check(rules: &Rules, raw: &str) -> bool {
-
     let trimmed: &str = raw.trim();
-    
     let alpha_cnt = trimmed.chars().filter(|c| c.is_alphabetic()).count();
     if trimmed.len() < rules.min_trimmed_length
         || rules.quote_start_with_letter

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -7,7 +7,7 @@ fn in_limit(x: usize, min_val: usize, max_val: usize) -> bool {
 }
 
 pub fn check(rules: &Rules, raw: &str) -> bool {
-    let trimmed: &str = raw.trim();
+    let trimmed = raw.trim();
     let alpha_cnt = trimmed.chars().filter(|c| c.is_alphabetic()).count();
     if trimmed.len() < rules.min_trimmed_length
         || rules.quote_start_with_letter

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -6,8 +6,22 @@ fn in_limit(x: usize, min_val: usize, max_val: usize) -> bool {
     x >= min_val && x <= max_val
 }
 
+fn maybe_remove_parentheses(rules: &Rules, line: &str) -> String {
+    if rules.remove_parentheses {
+        let regex = Regex::new("\\(.*\\)").unwrap();
+        let replaced = regex.replace_all(line, "").to_string();
+        println!("PAREN REMOVED: {}", replaced.as_str().replace("  ", " "));
+        return replaced.to_string().replace("  ", " ");
+    } else {
+        println!("PAREN KEPT: {}", line);
+        return line.to_string();
+    }
+}
+
 pub fn check(rules: &Rules, raw: &str) -> bool {
-    let trimmed = raw.trim();
+
+    let trimmed: &str = &maybe_remove_parentheses(rules, raw.trim());
+    
     let alpha_cnt = trimmed.chars().filter(|c| c.is_alphabetic()).count();
     if trimmed.len() < rules.min_trimmed_length
         || rules.quote_start_with_letter
@@ -264,6 +278,26 @@ mod test {
 
         assert!(!check(&rules, &String::from("foo")));
         assert!(check(&rules, &String::from("Foo")));
+    }
+
+    #[test]
+    fn test_remove_parentheses() {
+        let mut rules : Rules = Rules {
+            remove_parentheses: false,
+            ..Default::default()
+        };
+
+        assert_eq!(maybe_remove_parentheses(&rules, &String::from("First (content) should stay.")), "First (content) should stay.");
+        assert_ne!(maybe_remove_parentheses(&rules, &String::from("Second (content) should stay.")), "Second should stay.");
+
+        rules = Rules {
+            remove_parentheses: true,
+            ..Default::default()
+        };
+
+        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Third (content) should be removed.")), "Third should be removed.");
+        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Fourth (content (and nested one)) should be removed.")), "Fourth should be removed.");
+        assert_eq!(maybe_remove_parentheses(&rules, &String::from("Fifth [content (and nested one)] should partly be removed.")), "Fifth [content ] should partly be removed.");
     }
 
     #[test]

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -157,5 +157,6 @@ mod test {
         assert_eq!(replace_strings(&rules, &String::from("Fourth (content (and nested one)) only nested should be removed.")), "Fourth (content ) only nested should be removed.");
         assert_eq!(replace_strings(&rules, &String::from("Fifth [content (and nested one)] should partly be removed.")), "Fifth [content ] should partly be removed.");
         assert_ne!(replace_strings(&rules, &String::from("Sixth (content \n on \n multiple lines) should not be removed.")), "Sixth should not be removed.");
+        assert_eq!(replace_strings(&rules, &String::from("Seventh (one) and (two) 'and' should stay.")), "Seventh and 'and' should stay.");
     }
 }

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 fn maybe_remove_parentheses(rules: &Rules, txt: &str) -> String {
     let mut replaced = txt.to_string();
     if rules.remove_parentheses {
-        let regex = Regex::new("\\(.*\\)").unwrap();
+        let regex = Regex::new("\\([^\\()\n]*\\)").unwrap();
         replaced = regex.replace_all(txt, "").to_string().replace("  ", " ");
     }
     return replaced;
@@ -154,7 +154,7 @@ mod test {
         };
 
         assert_eq!(replace_strings(&rules, &String::from("Third (content) should be removed.")), "Third should be removed.");
-        assert_eq!(replace_strings(&rules, &String::from("Fourth (content (and nested one)) should be removed.")), "Fourth should be removed.");
+        assert_eq!(replace_strings(&rules, &String::from("Fourth (content (and nested one)) only nested should be removed.")), "Fourth (content ) only nested should be removed.");
         assert_eq!(replace_strings(&rules, &String::from("Fifth [content (and nested one)] should partly be removed.")), "Fifth [content ] should partly be removed.");
         assert_ne!(replace_strings(&rules, &String::from("Sixth (content \n on \n multiple lines) should not be removed.")), "Sixth should not be removed.");
     }

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -151,7 +151,6 @@ mod test {
         };
 
         assert_eq!(replace_strings(&rules, &String::from("One: (content) should stay.")), "One: (content) should stay.");
-        assert_ne!(replace_strings(&rules, &String::from("Two: (content) should stay.")), "Two: should stay.");
     }
 
     #[test]
@@ -164,10 +163,9 @@ mod test {
             ..Default::default()
         };
 
-        assert_eq!(replace_strings(&rules, &String::from("Three: (content) should be removed.")), "Three: should be removed.");
-        assert_eq!(replace_strings(&rules, &String::from("Four: [content (and nested one)] should be removed.")), "Four: should be removed.");
-        assert_eq!(replace_strings(&rules, &String::from("Five: (content (and nested one)) should be removed.")), "Five: should be removed.");
-        assert_eq!(replace_strings(&rules, &String::from("Six: (one) (two) and [three] 'and' should stay.")), "Six: and 'and' should stay.");
-        assert_ne!(replace_strings(&rules, &String::from("Seven: Test edge case (here).")), "Seven: Test edge case.");
+        assert_eq!(replace_strings(&rules, &String::from("Two: (content) should be removed.")), "Two: should be removed.");
+        assert_eq!(replace_strings(&rules, &String::from("Three: [content (and nested one)] should be removed.")), "Three: should be removed.");
+        assert_eq!(replace_strings(&rules, &String::from("Four: (content (and nested one)) should be removed.")), "Four: should be removed.");
+        assert_eq!(replace_strings(&rules, &String::from("Five: (one) (two) and [three] 'and' should stay.")), "Five: and 'and' should stay.");
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -48,7 +48,7 @@ pub struct Rules {
     pub needs_punctuation_end: bool,
     pub needs_uppercase_start: bool,
     pub needs_letter_start: bool,
-    pub remove_parentheses: bool,
+    pub remove_brackets_list: Array,
     pub allowed_symbols_regex: String,
     pub disallowed_symbols: Array,
     pub disallowed_words: HashSet<String>,
@@ -75,7 +75,7 @@ impl Default for Rules {
             needs_punctuation_end: false,
             needs_uppercase_start: false,
             needs_letter_start: true,
-            remove_parentheses: false,
+            remove_brackets_list: vec![],
             allowed_symbols_regex: String::from(""),
             disallowed_symbols: vec![],
             disallowed_words: HashSet::new(),
@@ -112,7 +112,7 @@ mod test {
         assert!(!rules.needs_punctuation_end);
         assert!(!rules.needs_uppercase_start);
         assert!(rules.needs_letter_start);
-        assert!(!rules.remove_parentheses);
+        assert_eq!(rules.remove_brackets_list, vec![]);
         assert_eq!(rules.allowed_symbols_regex, String::from(""));
         assert_eq!(rules.disallowed_symbols, vec![]);
         assert_eq!(rules.disallowed_words, HashSet::new());

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -48,6 +48,7 @@ pub struct Rules {
     pub needs_punctuation_end: bool,
     pub needs_uppercase_start: bool,
     pub needs_letter_start: bool,
+    pub remove_parentheses: bool,
     pub allowed_symbols_regex: String,
     pub disallowed_symbols: Array,
     pub disallowed_words: HashSet<String>,
@@ -74,6 +75,7 @@ impl Default for Rules {
             needs_punctuation_end: false,
             needs_uppercase_start: false,
             needs_letter_start: true,
+            remove_parentheses: false,
             allowed_symbols_regex: String::from(""),
             disallowed_symbols: vec![],
             disallowed_words: HashSet::new(),
@@ -110,6 +112,7 @@ mod test {
         assert!(!rules.needs_punctuation_end);
         assert!(!rules.needs_uppercase_start);
         assert!(rules.needs_letter_start);
+        assert!(!rules.remove_parentheses);
         assert_eq!(rules.allowed_symbols_regex, String::from(""));
         assert_eq!(rules.disallowed_symbols, vec![]);
         assert_eq!(rules.disallowed_words, HashSet::new());


### PR DESCRIPTION
This PR adds a new rule to optionally remove brackets from sentences before they are checked for other rules.

It will handle the issues mentioned in #198 ...

It will work like "replaces", before replaces and before any rule-check, so you can also run it with --no_check. This way you get all sentences but with content in parentheses removed.

You specify opening and closing brackets as a list, and they are executed from top to bottom.
```
[
  ["(", ")"],
  ["[", "]"],
]
```

- It can handle these cases:
  - This (definitely) is removed. => This is removed.
  - Works with (first) multiple (second) parentheses. => Works with multiple parentheses .
  - Handles nested (outer and [inner] and (another inner)) brackets => Handles nested brackets.

- Edge cases which cannot be handled:
  - Non-matching ((huh) brackets at the source. => Non-matching ( brackets at the source.
  - If not surrounded by spaces space is inserted (here). => If not surrounded by spaces space is inserted .

Tested on Turkish Wikipedia, with the same rules turning this feature off and on (no blacklist & no export limitation - i.e. 3 sentence/article limit removed): 5.8% increase in the number of total possible sentences (947,526 => 1,002,522)

EDITS:
- Changed this post to reflect the final code
- TESTED ON REAL DATA, CAN BE MERGED.
